### PR TITLE
fix: keep PreviewFrame mounted to prevent iframe focus issues with tab toggle

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -76,11 +76,12 @@ export function MainContent({ user, project }: MainContentProps) {
 
                 {/* Content Area */}
                 <div className="flex-1 overflow-hidden bg-neutral-50">
-                  {activeView === "preview" ? (
-                    <div className="h-full bg-white">
-                      <PreviewFrame />
-                    </div>
-                  ) : (
+                  {/* PreviewFrame stays mounted to avoid iframe remounting and focus issues */}
+                  <div className={activeView === "preview" ? "h-full bg-white" : "hidden"}>
+                    <PreviewFrame />
+                  </div>
+
+                  {activeView === "code" && (
                     <ResizablePanelGroup
                       direction="horizontal"
                       className="h-full"


### PR DESCRIPTION
Fixes the intermittent tab toggle issue where clicking Preview/Code buttons sometimes appeared to do nothing.

After interacting with the preview iframe, the iframe grabs browser focus. The first click on a tab button transferred focus back to the parent document without firing the click handler. Keeping PreviewFrame always mounted (CSS hidden instead of unmounting) resolves this.

Also improves performance - the preview no longer reloads when switching tabs.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)